### PR TITLE
#26 - Expose Refresh Token in Authenticated REST API requests

### DIFF
--- a/src/ManageTokens.php
+++ b/src/ManageTokens.php
@@ -293,6 +293,20 @@ class ManageTokens {
 	 */
 	public static function add_tokens_to_graphql_response_headers( $headers ) {
 
+		$should_return_tokens = false;
+
+		/**
+		 * If the request _is_ SSL, or GRAPHQL_DEBUG is defined, return the tokens
+		 * otherwise do not return them.
+		 */
+		if ( is_ssl() || defined( 'GRAPHQL_DEBUG' ) && true !== GRAPHQL_DEBUG ) {
+			$should_return_tokens = true;
+		}
+
+		if ( ! $should_return_tokens ) {
+			return $headers;
+		}
+
 		/**
 		 * If there's a Refresh-Authorization token in the request headers, validate it
 		 */
@@ -343,6 +357,20 @@ class ManageTokens {
 	 * @throws \Exception
 	 */
 	public static function add_auth_headers_to_rest_response( \WP_HTTP_Response $response, $handler, $request ) {
+
+		$should_return_tokens = false;
+
+		/**
+		 * If the request _is_ SSL, or GRAPHQL_DEBUG is defined, return the tokens
+		 * otherwise do not return them.
+		 */
+		if ( is_ssl() || defined( 'GRAPHQL_DEBUG' ) && true !== GRAPHQL_DEBUG ) {
+			$should_return_tokens = true;
+		}
+
+		if ( ! $should_return_tokens ) {
+			return $response;
+		}
 
 		/**
 		 * Note: The Access-Control-Expose-Headers aren't directly filterable

--- a/src/ManageTokens.php
+++ b/src/ManageTokens.php
@@ -293,17 +293,11 @@ class ManageTokens {
 	 */
 	public static function add_tokens_to_graphql_response_headers( $headers ) {
 
-		$should_return_tokens = false;
-
 		/**
 		 * If the request _is_ SSL, or GRAPHQL_DEBUG is defined, return the tokens
 		 * otherwise do not return them.
 		 */
-		if ( is_ssl() || defined( 'GRAPHQL_DEBUG' ) && true !== GRAPHQL_DEBUG ) {
-			$should_return_tokens = true;
-		}
-
-		if ( ! $should_return_tokens ) {
+		if ( ! is_ssl() && ( ! defined( 'GRAPHQL_DEBUG' ) || true !== GRAPHQL_DEBUG ) ) {
 			return $headers;
 		}
 
@@ -358,17 +352,11 @@ class ManageTokens {
 	 */
 	public static function add_auth_headers_to_rest_response( \WP_HTTP_Response $response, $handler, $request ) {
 
-		$should_return_tokens = false;
-
 		/**
 		 * If the request _is_ SSL, or GRAPHQL_DEBUG is defined, return the tokens
 		 * otherwise do not return them.
 		 */
-		if ( is_ssl() || defined( 'GRAPHQL_DEBUG' ) && true !== GRAPHQL_DEBUG ) {
-			$should_return_tokens = true;
-		}
-
-		if ( ! $should_return_tokens ) {
+		if ( ! is_ssl() && ( ! defined( 'GRAPHQL_DEBUG' ) || true !== GRAPHQL_DEBUG ) ) {
 			return $response;
 		}
 

--- a/src/ManageTokens.php
+++ b/src/ManageTokens.php
@@ -364,10 +364,6 @@ class ManageTokens {
 
 			$refresh_token = Auth::get_refresh_token( new \WP_User( $validate_auth_header->data->user->id ), false );
 
-			if ( ! empty( $refresh_token ) && ! is_wp_error( $refresh_token ) ) {
-				$headers['X-JWT-Refresh'] = $refresh_token;
-			}
-
 		}
 
 		if ( $refresh_token ) {


### PR DESCRIPTION
This exposes `X-JWT-Refresh` in the repsonse headers of REST API requests that were authenticated with a WPGraphQL issued JWT Auth Token. 

You can see this in action in the below GIF where I: 

- Login via GraphQL to get an authToken
- Use the authToken as my Authorizaton token in a WP REST API request
- See a `X-JWT-Refresh` token in the REST API response headers

![x-jwt-auth-rest-response](https://user-images.githubusercontent.com/1260765/53048992-4bca7480-3453-11e9-8e51-3b6fe59d2b34.gif)
