### PR TITLE
Revert "#26 - remove unused filter that was causing issues with expiration dates"

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -99,7 +99,7 @@ class Auth {
 	 */
 	public static function get_token_expiration() {
 
-		if ( ! isset( self::$expiration ) || empty( self::$expiration ) ) {
+		if ( ! isset( self::$expiration ) ) {
 
 			/**
 			 * Set the expiration time, default is 300 seconds.
@@ -107,7 +107,7 @@ class Auth {
 			$expiration = self::get_token_issued() + 300;
 
 			/**
-			 * Determine the expiration value. Default is 5 minutes, but is filterable to be configured as needed
+			 * Determine the expiration value. Default is 7 days, but is filterable to be configured as needed
 			 *
 			 * @param string $expiration The timestamp for when the token should expire
 			 */


### PR DESCRIPTION
Reverts wp-graphql/wp-graphql-jwt-authentication#29