### PR TITLE
Update wp-graphql-jwt-authentication.php

### DIFF
--- a/wp-graphql-jwt-authentication.php
+++ b/wp-graphql-jwt-authentication.php
@@ -202,4 +202,4 @@ function init() {
 	return JWT_Authentication::instance();
 }
 
-add_action( 'plugins_loaded', '\WPGraphQL\JWT_Authentication\init' );
+add_action( 'plugins_loaded', '\WPGraphQL\JWT_Authentication\init', 9 );


### PR DESCRIPTION
Lower priority of `plugins_loaded` to run before other plugins that might initialize the user. See https://github.com/wp-graphql/wp-graphql-jwt-authentication/issues/35 for details