### PR TITLE
#38 - Invalid or expired JWT tokens should prevent request from being serviced

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -527,7 +527,7 @@ class Auth {
 			 * @since 0.0.1
 			 */
 			if ( empty( $auth_header ) ) {
-				return false;
+				return $token;
 			} else {
 				/**
 				 * The HTTP_AUTHORIZATION is present verify the format
@@ -542,52 +542,60 @@ class Auth {
 		 * If there's no secret key, throw an error as there needs to be a secret key for Auth to work properly
 		 */
 		if ( ! self::get_secret_key() ) {
-			throw new \Exception( __( 'JWT is not configured properly', 'wp-graphql-jwt-authentication' ) );
+			self::set_status( 403 );
+			return new \WP_Error( 'invalid-secret-key', __( 'JWT is not configured properly', 'wp-graphql-jwt-authentication' ) );
+		}
+
+
+
+		/**
+		 * Decode the Token
+		 */
+		JWT::$leeway = 60;
+
+		$secret = self::get_secret_key();
+
+		try {
+			$token = ! empty( $token ) ? JWT::decode( $token, $secret, [ 'HS256' ] ) : null;
+		} catch ( \Exception $exception ) {
+			$token =  new \WP_Error( 'invalid-secret-key', $exception->getMessage() );
 		}
 
 		/**
-		 * Try to decode the token
+		 * If there's no token listed, just bail now before validating an empty token.
+		 * This will treat the request as a public request
 		 */
-		try {
+		if ( empty( $token )  ) {
+			return $token;
+		}
 
-			/**
-			 * Decode the Token
-			 */
-			JWT::$leeway = 60;
+		/**
+		 * The Token is decoded now validate the iss
+		 */
+		if ( ! isset( $token->iss ) || get_bloginfo( 'url' ) !== $token->iss ) {
+			$token = new \WP_Error( 'invalid-jwt', __( 'The iss do not match with this server', 'wp-graphql-jwt-authentication' ) );
+		}
 
-			$secret = self::get_secret_key();
-			$token = ! empty( $token ) ? JWT::decode( $token, $secret, [ 'HS256' ] ) : null;
 
-			/**
-			 * The Token is decoded now validate the iss
-			 */
-			if ( ! isset( $token->iss ) || get_bloginfo( 'url' ) !== $token->iss ) {
-				throw new \Exception( __( 'The iss do not match with this server', 'wp-graphql-jwt-authentication' ) );
+		/**
+		 * So far so good, validate the user id in the token
+		 */
+		if ( ! isset( $token->data->user->id ) ) {
+			$token = new \WP_Error( 'invalid-jwt', __( 'User ID not found in the token', 'wp-graphql-jwt-authentication' ) );
+		}
+
+		/**
+		 * If there is a user_secret in the token (refresh tokens) make sure it matches what
+		 */
+		if ( isset( $token->data->user->user_secret ) ) {
+
+			if ( Auth::is_jwt_secret_revoked( $token->data->user->id ) ) {
+				$token = new \WP_Error( 'invalid-jwt', __( 'The User Secret does not match or has been revoked for this user', 'wp-graphql-jwt-authentication' ) );
 			}
+		}
 
-			/**
-			 * So far so good, validate the user id in the token
-			 */
-			if ( ! isset( $token->data->user->id ) ) {
-				throw new \Exception( __( 'User ID not found in the token', 'wp-graphql-jwt-authentication' ) );
-			}
-
-			/**
-			 * If there is a user_secret in the token (refresh tokens) make sure it matches what
-			 */
-			if ( isset( $token->data->user->user_secret ) ) {
-
-				if ( Auth::is_jwt_secret_revoked( $token->data->user->id ) ) {
-					throw new \Exception( __( 'The User Secret does not match or has been revoked for this user', 'wp-graphql-jwt-authentication' ) );
-				}
-			}
-
-			/**
-			 * If any exceptions are caught
-			 */
-		} catch ( \Exception $error ) {
+		if ( is_wp_error( $token ) ) {
 			self::set_status( 403 );
-			return new \WP_Error( 'invalid_token', __( 'The JWT Token is invalid', 'wp-graphql-jwt-authentication' ) );
 		}
 
 		self::$is_refresh_token = false;

--- a/wp-graphql-jwt-authentication.php
+++ b/wp-graphql-jwt-authentication.php
@@ -177,6 +177,21 @@ if ( ! class_exists( '\WPGraphQL\JWT_Authentication' ) ) :
 			], 99, 1 );
 
 			/**
+			 * When the GraphQL Request is initiated, validate the token.
+			 *
+			 * If the Auth Token is not valid, prevent execution of resolvers. This will also set the
+			 * response status to 403.
+			 */
+			add_action( 'init_graphql_request', function() {
+				$token = Auth::validate_token();
+				if ( is_wp_error( $token ) ) {
+					add_action( 'graphql_before_resolve_field', function() use ( $token ) {
+						throw new \Exception( $token->get_error_code() . ' | ' . $token->get_error_message() );
+					}, 1 );
+				}
+			} );
+
+			/**
 			 * Filter the rootMutation fields
 			 */
 			add_filter( 'graphql_rootMutation_fields', [


### PR DESCRIPTION
- This validates the Auth Token when the GraphQL Request is being initiated, and if it's invalid the request does not execute and a 403 status is returned.

closes #38 

@mlipscombe when you have a chance can you confirm this works with your consuming application without issues?