### PR TITLE
Removed vendor from .distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -22,7 +22,6 @@ phpcs.ruleset.xml
 README.md
 wp-cli.local.yml
 tests
-vendor
 node_modules
 *.zip
 *.tar.gz


### PR DESCRIPTION
Ran into an issue today with this plugin. We use [Satispress](https://github.com/cedaro/satispress) to manage our plugins via Composer. It uses the .distignore file to remove files from the plugin archive before distributing it via composer. I was getting an error about missing files in the vendor folder on one of my sites. Looks like .distignore was remove this folder. I've taken vendor out of .distignore to resolve this issue