### PR TITLE
Adds user ID to LoginPayload

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -71,6 +71,7 @@ class Auth {
 			'authToken'    => self::get_signed_token( $user ),
 			'refreshToken' => self::get_refresh_token( $user ),
 			'user'         => DataSource::resolve_user( $user->data->ID, \WPGraphQL::get_app_context() ),
+			'id'           => $user->data->ID,
 		];
 
 		/**


### PR DESCRIPTION
Adds user ID to LoginPayload. This will make it possible to register object associated with the user the to LoginPayload, like WooGraphQL's `Customer`.