### PR TITLE
#45 - auth and refresh token are same for non-admins

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -216,10 +216,10 @@ class Auth {
 		$capability = apply_filters( 'graphql_jwt_auth_edit_users_capability', 'edit_users', $user_id );
 
 		/**
-		 * If the request is not from the current_user or the current_user doesn't have the proper capabilities, don't return the secret
+		 * If the request is not from the current_user AND the current_user doesn't have the proper capabilities, don't return the secret
 		 */
 		$is_current_user = ( $user_id === get_current_user_id() ) ? true : false;
-		if ( ! $is_current_user || ! current_user_can( $capability ) ) {
+		if ( ! $is_current_user && ! current_user_can( $capability ) ) {
 			return new \WP_Error( 'graphql-jwt-improper-capabilities', __( 'The JWT Auth secret for this user cannot be returned', 'wp-graphql-jwt-authentication' ) );
 		}
 


### PR DESCRIPTION
- if the token doesn't belong to the current user AND the current user doesn't have proper caps, throw an error

closes #45 