### PR TITLE
#69 - JWT Tokens could not be returned after regiserUser mutation

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -200,11 +200,13 @@ class Auth {
 	 */
 	public static function get_user_jwt_secret( $user_id ) {
 
+		$is_revoked = Auth::is_jwt_secret_revoked( $user_id );
+
 		/**
 		 * If the secret has been revoked, throw an error
 		 */
-		if ( true === Auth::is_jwt_secret_revoked( $user_id ) ) {
-			return new \WP_Error( 'graphql-jwt-revoked-secret', __( 'The JWT Auth secret cannot be returned', 'wp-graphql-jwt-authentication' ) );
+		if ( true === (bool) $is_revoked ) {
+			return null;
 		}
 
 		/**
@@ -220,7 +222,7 @@ class Auth {
 		 */
 		$is_current_user = ( $user_id === get_current_user_id() ) ? true : false;
 		if ( ! $is_current_user || ! current_user_can( $capability ) ) {
-			return new \WP_Error( 'graphql-jwt-improper-capabilities', __( 'The JWT Auth secret for this user cannot be returned', 'wp-graphql-jwt-authentication' ) );
+			return null;
 		}
 
 		/**

--- a/src/ManageTokens.php
+++ b/src/ManageTokens.php
@@ -75,14 +75,18 @@ class ManageTokens {
 					'type'        => 'String',
 					'description' => __( 'A JWT token that can be used in future requests for authentication/authorization', 'wp-graphql-jwt-authentication' ),
 					'resolve'     => function ( $user ) {
-						$user = get_user_by( 'id', $user->ID );
+						$user = get_user_by( 'id', $user->userId );
 
 						// Get the token for the user.
 						$token = Auth::get_token( $user );
 
 						// If the token cannot be returned, throw an error.
-						if ( empty( $token ) || is_wp_error( $token ) ) {
+						if ( empty( $token ) ) {
 							throw new UserError( __( 'The JWT token could not be returned', 'wp-graphql-jwt-authentication' ) );
+						}
+
+						if ( $token instanceof \WP_Error ) {
+							throw new UserError( $token->get_error_message() );
 						}
 
 						return ! empty( $token ) ? $token : null;
@@ -92,14 +96,19 @@ class ManageTokens {
 					'type'        => 'String',
 					'description' => __( 'A JWT token that can be used in future requests to get a refreshed jwtAuthToken. If the refresh token used in a request is revoked or otherwise invalid, a valid Auth token will NOT be issued in the response headers.', 'wp-graphql-jwt-authentication' ),
 					'resolve'     => function ( $user ) {
-						$user = get_user_by( 'id', $user->ID );
+
+						$user = get_user_by( 'id', $user->userId );
 
 						// Get the token for the user.
 						$token = Auth::get_refresh_token( $user );
 
 						// If the token cannot be returned, throw an error.
-						if ( empty( $token ) || is_wp_error( $token ) ) {
+						if ( empty( $token ) ) {
 							throw new UserError( __( 'The JWT token could not be returned', 'wp-graphql-jwt-authentication' ) );
+						}
+
+						if ( $token instanceof \WP_Error ) {
+							throw new UserError( $token->get_error_message() );
 						}
 
 						return ! empty( $token ) ? $token : null;
@@ -110,11 +119,11 @@ class ManageTokens {
 					'description' => __( 'A unique secret tied to the users JWT token that can be revoked or refreshed. Revoking the secret prevents JWT tokens from being issued to the user. Refreshing the token invalidates previously issued tokens, but allows new tokens to be issued.', 'wp-graphql' ),
 					'resolve'     => function ( $user ) {
 						// Get the user's JWT Secret.
-						$secret = Auth::get_user_jwt_secret( $user->ID );
+						$secret = Auth::get_user_jwt_secret( $user->userId );
 
 						// If the secret cannot be returned, throw an error.
-						if ( is_wp_error( $secret ) ) {
-							throw new UserError( __( 'The user secret could not be returned', 'wp-graphql-jwt-authentication' ) );
+						if ( $secret instanceof \WP_Error ) {
+							throw new UserError( $secret->get_error_message() );
 						}
 
 						// Return the secret.
@@ -134,7 +143,7 @@ class ManageTokens {
 					'type'        => [ 'non_null' => 'Boolean' ],
 					'description' => __( 'Whether the JWT User secret has been revoked. If the secret has been revoked, auth tokens will not be issued until an admin, or user with proper capabilities re-issues a secret for the user.', 'wp-graphql-jwt-authentication' ),
 					'resolve'     => function ( $user ) {
-						$revoked = Auth::is_jwt_secret_revoked( $user->ID );
+						$revoked = Auth::is_jwt_secret_revoked( $user->userId );
 
 						return true === $revoked ? true : false;
 					},


### PR DESCRIPTION
- This updates the mutations to expect a User model to be passed through instead of a WP_User object
- This also updates some of the errors to be more clear, passing through WP_Error messages
- This also returns null when the user cannot access the JWT Secret instead of throwing an error.

----

Closes #69 