### PR TITLE
Fix Auth Expiration time filter and add it to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ mutation RefreshAuthToken {
 }
 ```
 
+## Filters
+
+The plugin offers some filters to hook into.
+
+### Change Auth Token expiry time
+
+**Note: For security, we highly recommend, that the Auth Token is short lived. So do not set this higher than 300 seconds unless you know what you are doing.**
+
+```php
+add_filter('graphql_jwt_auth_expire', 60);
+```
+
+- Argument: Expiry time in seconds
+- Default: 300
+
 
 ## Example using GraphiQL
 ![Example using GraphiQL](https://github.com/wp-graphql/wp-graphql-jwt-authentication/blob/master/img/jwt-auth-example.gif?raw=true)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ mutation RefreshAuthToken {
 
 The plugin offers some filters to hook into.
 
-### Change Auth Token expiry time
+### Change Auth Token expiration
 
 **Note: For security, we highly recommend, that the Auth Token is short lived. So do not set this higher than 300 seconds unless you know what you are doing.**
 
@@ -133,7 +133,7 @@ The plugin offers some filters to hook into.
 add_filter('graphql_jwt_auth_expire', 60);
 ```
 
-- Argument: Expiry time in seconds
+- Argument: Expiration in seconds
 - Default: 300
 
 

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -105,19 +105,17 @@ class Auth {
 			/**
 			 * Set the expiration time, default is 300 seconds.
 			 */
-			$expiration = self::get_token_issued() + 300;
+			$expiration = 300;
 
 			/**
-			 * Determine the expiration value. Default is 7 days, but is filterable to be configured as needed
+			 * Determine the expiration value. Default is 5 minutes, but is filterable to be configured as needed
 			 *
 			 * @param string $expiration The timestamp for when the token should expire
 			 */
-			self::$expiration = apply_filters( 'graphql_jwt_auth_expire', $expiration );
-
+			self::$expiration = self::get_token_issued() + apply_filters( 'graphql_jwt_auth_expire', $expiration );
 		}
 
 		return ! empty( self::$expiration ) ? self::$expiration : null;
-
 	}
 
 	/**


### PR DESCRIPTION
This would be the fist step to document the filters and also it fixes the `graphql_jwt_auth_expire` filter. Now it can be used like this:

```php
add_filter('graphql_jwt_auth_expire', 60);
```