### PR TITLE
fix(response headers): replace single header instead of overwriting them all

### DIFF
--- a/src/ManageTokens.php
+++ b/src/ManageTokens.php
@@ -342,9 +342,7 @@ class ManageTokens {
 		 *
 		 * Might need a patch to core to allow for individual filtering.
 		 */
-		$response->set_headers(
-			[ 'Access-Control-Expose-Headers' => 'X-WP-Total, X-WP-TotalPages, X-JWT-Refresh' ]
-		);
+		$response->header( 'Access-Control-Expose-Headers', 'X-WP-Total, X-WP-TotalPages, X-JWT-Refresh', true );
 
 		$refresh_token = null;
 
@@ -357,7 +355,7 @@ class ManageTokens {
 		}
 
 		if ( $refresh_token ) {
-			$response->set_headers( [ 'X-JWT-Refresh' => $refresh_token ] );
+			$response->header( 'X-JWT-Refresh', $refresh_token, true );
 		}
 
 		return $response;


### PR DESCRIPTION
updated to call the 'header' instead of 'set_headers' method when writing response headers to avoid
overwriting all the headers such as X-WP-Total and X-WP-TotalPages which are necessary for different
plugins and pieces of Wordpress to work properly