### PR TITLE
Fix incorrect error message on invalid secret

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -571,7 +571,7 @@ class Auth {
 		try {
 			$token = ! empty( $token ) ? JWT::decode( $token, $secret, [ 'HS256' ] ) : null;
 		} catch ( \Exception $exception ) {
-			$token =  new \WP_Error( 'invalid-secret-key', $exception->getMessage() );
+			return new \WP_Error( 'invalid-secret-key', $exception->getMessage() );
 		}
 
 		/**


### PR DESCRIPTION
If a token with an invalid secret key is passed, the error returned will be `The iss do not match with this server` when the `iss` field is set correctly. This PR fixes that.