### PR TITLE
Add filters to authentication flow to allow external authentication

### DIFF
--- a/src/Login.php
+++ b/src/Login.php
@@ -49,7 +49,7 @@ class Login {
 				],
 				'mutateAndGetPayload' => function( $input, AppContext $context, ResolveInfo $info ) {
 					// Login the user in and get an authToken and user in response.
-					return Auth::login_and_get_token( sanitize_user( $input['username'] ), trim( $input['password'] ) );
+					return Auth::login_and_get_token( sanitize_user( $input['username'] ), trim( $input['password'] ),$input );
 				},
 			]
 		);


### PR DESCRIPTION
Adds two filters:
`graphql_jwt_auth_use_wp_authentication` -- returns boolean to determine if should use WP authentication
`graphql_jwt_auth_authenticate_user` -- returns authenticated user or WP_Error

Also passes full query input along to Auth functions and filters to give SSO provider access to data