### PR TITLE
Bug/#144 do not execute for refresh token used as authorization token

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -604,6 +604,14 @@ class Auth {
 			if ( Auth::is_jwt_secret_revoked( $token->data->user->id ) ) {
 				return new \WP_Error( 'invalid-jwt', __( 'The User Secret does not match or has been revoked for this user', 'wp-graphql-jwt-authentication' ) );
 			}
+
+			/**
+             * Check if the refresh token is not provided as auth token
+             */
+			if ( $refresh===false) {
+				return new \WP_Error( 'invalid-jwt', __( 'Refresh token is not allowd as auth token!', 'wp-graphql-jwt-authentication' ) );
+			}
+			
 		}
 
 		if ( is_wp_error( $token ) ) {

--- a/wp-graphql-jwt-authentication.php
+++ b/wp-graphql-jwt-authentication.php
@@ -7,7 +7,7 @@
  * Author URI: https://www.wpgraphql.com
  * Text Domain: wp-graphql-jwt-authentication-jwt-authentication
  * Domain Path: /languages
- * Version: 0.4.0
+ * Version: 0.4.1
  * Requires at least: 4.7.0
  * Tested up to: 4.8.3
  * Requires PHP: 5.5
@@ -113,7 +113,7 @@ if ( ! class_exists( '\WPGraphQL\JWT_Authentication' ) ) :
 		private function setup_constants() {
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_JWT_AUTHENTICATION_VERSION' ) ) {
-				define( 'WPGRAPHQL_JWT_AUTHENTICATION_VERSION', '0.4.0' );
+				define( 'WPGRAPHQL_JWT_AUTHENTICATION_VERSION', '0.4.1' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
##### #144 #136 ...
##### Bug fix!
##### This update prevents execution of mutations from refreshToken misused in authorization header as authToken.
##### Feel free to comment