### PR TITLE
Remove codecept_debug which causes internal server error

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -584,8 +584,6 @@ class Auth {
 		 */
 		JWT::$leeway = 60;
 
-		codecept_debug( [ 'tokenYo' => $token ] );
-
 		try {
 			$token = ! empty( $token ) ? JWT::decode( $token, new Key( self::get_secret_key(), 'HS256') ) : null;
 		} catch ( Exception $exception ) {


### PR DESCRIPTION
The `codecept_debug` function, used for unit tests, probably shouldn't be in the plugin production code.
This causes an internal server error due to undefined function in the WordPress ecosystem.

The detailed error is:
```console
PHP Fatal error: Uncaught Error: Call to undefined function WPGraphQL\JWT_Authentication\codecept_debug()
```

This is reproducible only by querying under authorization, not with default queries.

During the build, Next.js + Apollo Client show this error:
```console
[Network error]: ServerError: Response not successful: Received status code 500
```

Related issues:
[#158](https://github.com/wp-graphql/wp-graphql-jwt-authentication/issues/158)
[#157](https://github.com/wp-graphql/wp-graphql-jwt-authentication/issues/157)