### PR TITLE
Release/v0.6.0

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -370,10 +370,19 @@ class Auth {
 	 */
 	protected static function authenticate_user( $username, $password ) {
 
-		/**
-		 * Try to authenticate the user with the passed credentials
-		 */
-		$user = wp_authenticate( sanitize_user( $username ), trim( $password ) );
+		if ( defined( 'GRAPHQL_JWT_AUTH_SET_COOKIES' ) && ! empty( GRAPHQL_JWT_AUTH_SET_COOKIES ) && GRAPHQL_JWT_AUTH_SET_COOKIES ) {
+			$credentials = [
+				'user_login'  => sanitize_user( $username ),
+				'user_password'  => trim( $password ),
+				'remember'  => false,
+			];
+
+			 // Try to authenticate the user with the passed credentials, log him in and set cookies
+			$user = wp_signon( $credentials, true );
+		} else {
+			 // Try to authenticate the user with the passed credentials
+			$user = wp_authenticate( sanitize_user( $username ), trim( $password ) );
+		}
 
 		/**
 		 * If the authentication fails return a error

--- a/src/ManageTokens.php
+++ b/src/ManageTokens.php
@@ -342,9 +342,7 @@ class ManageTokens {
 		 *
 		 * Might need a patch to core to allow for individual filtering.
 		 */
-		$response->set_headers(
-			[ 'Access-Control-Expose-Headers' => 'X-WP-Total, X-WP-TotalPages, X-JWT-Refresh' ]
-		);
+		$response->header( 'Access-Control-Expose-Headers', 'X-WP-Total, X-WP-TotalPages, X-JWT-Refresh', true );
 
 		$refresh_token = null;
 
@@ -357,7 +355,7 @@ class ManageTokens {
 		}
 
 		if ( $refresh_token ) {
-			$response->set_headers( [ 'X-JWT-Refresh' => $refresh_token ] );
+			$response->header( 'X-JWT-Refresh', $refresh_token, true );
 		}
 
 		return $response;

--- a/wp-graphql-jwt-authentication.php
+++ b/wp-graphql-jwt-authentication.php
@@ -7,7 +7,7 @@
  * Author URI: https://www.wpgraphql.com
  * Text Domain: wp-graphql-jwt-authentication-jwt-authentication
  * Domain Path: /languages
- * Version: 0.5.3
+ * Version: 0.6.0
  * Requires at least: 4.7.0
  * Tested up to: 4.8.3
  * Requires PHP: 5.5
@@ -113,7 +113,7 @@ if ( ! class_exists( '\WPGraphQL\JWT_Authentication' ) ) :
 		private function setup_constants() {
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_JWT_AUTHENTICATION_VERSION' ) ) {
-				define( 'WPGRAPHQL_JWT_AUTHENTICATION_VERSION', '0.5.3' );
+				define( 'WPGRAPHQL_JWT_AUTHENTICATION_VERSION', '0.6.0' );
 			}
 
 			// Plugin Folder Path.

--- a/wp-graphql-jwt-authentication.php
+++ b/wp-graphql-jwt-authentication.php
@@ -7,7 +7,7 @@
  * Author URI: https://www.wpgraphql.com
  * Text Domain: wp-graphql-jwt-authentication-jwt-authentication
  * Domain Path: /languages
- * Version: 0.5.2
+ * Version: 0.5.3
  * Requires at least: 4.7.0
  * Tested up to: 4.8.3
  * Requires PHP: 5.5
@@ -113,7 +113,7 @@ if ( ! class_exists( '\WPGraphQL\JWT_Authentication' ) ) :
 		private function setup_constants() {
 			// Plugin version.
 			if ( ! defined( 'WPGRAPHQL_JWT_AUTHENTICATION_VERSION' ) ) {
-				define( 'WPGRAPHQL_JWT_AUTHENTICATION_VERSION', '0.5.2' );
+				define( 'WPGRAPHQL_JWT_AUTHENTICATION_VERSION', '0.5.3' );
 			}
 
 			// Plugin Folder Path.


### PR DESCRIPTION
## Release Notes

fix: fixes a bug where all headers were being replaced instead of adding headers. Thanks, and happy anniversary @tsmith-rv.
feat: When the `GRAPHQL_JWT_AUTH_SET_COOKIES` constant is set to true, WordPress will set the cookies upon successful authentication with JWT Auth. Thanks @henrikwirth!