### PR TITLE
fix: php-jwt version fixed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "wpunit-test": "vendor/bin/codecept run wpunit"
   },
   "require": {
-    "firebase/php-jwt": "6.1.0"
+    "firebase/php-jwt": "^6.1.0"
   },
   "require-dev": {
     "lucatume/wp-browser": "3.1.0",


### PR DESCRIPTION
# Summary
- Adds the `^` to stop version locking and conflict when pull into an application with a peer dependency on `firebase/php-jwt`.