### PR TITLE
Fixes inconsistent error messages

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -388,8 +388,8 @@ class Auth {
 		 * If the authentication fails return a error
 		 */
 		if ( is_wp_error( $user ) ) {
-			$error_code = ! empty( $user->get_error_code() ) ? $user->get_error_code() : 'invalid login';
-			throw new UserError( esc_html( $error_code ) );
+			$error_message = ! empty( $user->get_error_message() ) ? $user->get_error_message() : 'invalid login';
+			throw new UserError( esc_html( $error_message ) );
 		}
 
 		return ! empty( $user ) ? $user : null;

--- a/src/ManageTokens.php
+++ b/src/ManageTokens.php
@@ -128,7 +128,7 @@ class ManageTokens {
 						}
 
 						if ( is_wp_error( $token ) ) {
-							throw new UserError( esc_html ( $token->get_error_message() ) );
+							throw new UserError( esc_html( $token->get_error_message() ) );
 						}
 
 						return ! empty( $token ) ? $token : null;

--- a/src/ManageTokens.php
+++ b/src/ManageTokens.php
@@ -96,8 +96,8 @@ class ManageTokens {
 							throw new UserError( __( 'The JWT token could not be returned', 'wp-graphql-jwt-authentication' ) );
 						}
 
-						if ( $token instanceof \WP_Error ) {
-							throw new UserError( $token->get_error_message() );
+						if ( is_wp_error( $token ) ) {
+							throw new UserError( esc_html( $token->get_error_message() ) );
 						}
 
 						return ! empty( $token ) ? $token : null;
@@ -127,8 +127,8 @@ class ManageTokens {
 							throw new UserError( __( 'The JWT token could not be returned', 'wp-graphql-jwt-authentication' ) );
 						}
 
-						if ( $token instanceof \WP_Error ) {
-							throw new UserError( $token->get_error_message() );
+						if ( is_wp_error( $token ) ) {
+							throw new UserError( esc_html ( $token->get_error_message() ) );
 						}
 
 						return ! empty( $token ) ? $token : null;
@@ -151,8 +151,8 @@ class ManageTokens {
 						$secret = Auth::get_user_jwt_secret( $user_id );
 
 						// If the secret cannot be returned, throw an error.
-						if ( $secret instanceof \WP_Error ) {
-							throw new UserError( $secret->get_error_message() );
+						if ( is_wp_error( $secret ) ) {
+							throw new UserError( esc_html( $secret->get_error_message() ) );
 						}
 
 						// Return the secret.

--- a/wp-graphql-jwt-authentication.php
+++ b/wp-graphql-jwt-authentication.php
@@ -197,7 +197,7 @@ if ( ! class_exists( '\WPGraphQL\JWT_Authentication' ) ) :
 					$token = Auth::validate_token();
 					if ( is_wp_error( $token ) ) {
 						add_action( 'graphql_before_resolve_field', function() use ( $token ) {
-							throw new \Exception( $token->get_error_code() . ' | ' . $token->get_error_message() );
+							throw new \Exception( esc_html( $token->get_error_message() ) );
 						}, 1 );
 					}
 				}


### PR DESCRIPTION
Most errors messages defined by the plugin are normally full messages:

E.g. `throw new UserError( __( 'The JWT token could not be returned', 'wp-graphql-jwt-authentication' ) );`

Nevertheless, on some occasions, it is returning the error code. 

`$error_code = ! empty( $user->get_error_code() ) ? $user->get_error_code() : 'invalid login';`

or both combined:

`throw new \Exception( $token->get_error_code() . ' | ' . $token->get_error_message() );`

This PR adds consistency in terms of how the error is checked (`is_wp_error()`') and what is returned (`error->get_error_message()`. It also escapes the output for improved security. 
