### PR TITLE
[FIX] #173 - PHP 8.1 deprecation warning 

### DIFF
--- a/src/ManageTokens.php
+++ b/src/ManageTokens.php
@@ -346,7 +346,9 @@ class ManageTokens {
 
 		$refresh_token = null;
 
-		$validate_auth_header = Auth::validate_token( str_ireplace( 'Bearer ', '', Auth::get_auth_header() ), false );
+		// Extract the authorization header and validate it.
+		$auth_header          = Auth::get_auth_header() ? Auth::get_auth_header() : '';
+		$validate_auth_header = Auth::validate_token( str_ireplace( 'Bearer ', '', $auth_header ), false );
 
 		if ( ! is_wp_error( $validate_auth_header ) && ! empty( $validate_auth_header->data->user->id ) ) {
 


### PR DESCRIPTION
### Description

A quick ternary to check for `Auth::get_auth_header()` before trying to use the value.

Error:

```text
 PHP Deprecated:  str_ireplace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /app/public/wp-content/plugins/wp-graphql-jwt-authentication/src/ManageTokens.php on line 349
```

### Related Issue

Closes #173 